### PR TITLE
Split the tunnel-p2p-params_config grouping in multiple groups

### DIFF
--- a/ietf-te-path-computation.yang
+++ b/ietf-te-path-computation.yang
@@ -268,8 +268,8 @@ module ietf-te-path-computation {
 	 */
 	
   grouping encoding-and-switching-type {
-		description
-		  "Common grouping to define the LSP encoding and switching types"
+    description
+      "Common grouping to define the LSP encoding and switching types"
 
     leaf encoding {
       type identityref {
@@ -287,25 +287,11 @@ module ietf-te-path-computation {
     }
   }
 
-	grouping preference {
-		description
-		  "Common grouping to define the tunnel/path preference"
-
-		leaf preference {
-      type uint8 {
-        range "1..255";
-      }
-      description
-        "Specifies a preference for this tunnel.
-        A lower number signifies a better preference";
-    }
-	}
-	
   grouping end-points {
-		description
-		  "Common grouping to define the TE tunnel end-points"
+    description
+      "Common grouping to define the TE tunnel end-points"
 
-		leaf source {
+    leaf source {
       type inet:ip-address;
       description "TE tunnel source address.";
     }
@@ -353,8 +339,7 @@ module ietf-te-path-computation {
           It must be present also in rpcs.";
       }
       uses end-points;
-			uses encoding-and-switching-type;
-      uses preference;
+      uses encoding-and-switching-type;
       uses te:bidir-assoc-properties;
       uses te-types:path-route-objects;
       uses te-types:generic-path-constraints;

--- a/ietf-te-path-computation.yang
+++ b/ietf-te-path-computation.yang
@@ -39,8 +39,8 @@ module ietf-te-path-computation {
 
   description "YANG model for stateless TE path computation";
   
-  revision "2018-03-02" {
-    description "Revision to fix issues #22, 29, 33 and 39";
+  revision "2018-04-09" {
+    description "Pull request to fix issue #31";
     reference "YANG model for stateless TE path computation";
   }
 
@@ -58,7 +58,7 @@ module ietf-te-path-computation {
   /*
    * Groupings
    */
-   
+
   grouping path-info {
     leaf path-id {
       type yang-types:uuid;
@@ -69,26 +69,6 @@ module ietf-te-path-computation {
     description "Path computation output information";
   }
   
-  grouping end-points {
-    leaf source {
-      type inet:ip-address;
-      description "TE tunnel source address.";
-    }
-    leaf destination {
-      type inet:ip-address;
-      description "P2P tunnel destination address";
-    }
-    leaf src-tp-id {
-      type binary;
-      description "TE tunnel source termination point identifier.";
-    }
-    leaf dst-tp-id {
-      type binary;
-      description "TE tunnel destination termination point identifier.";
-    }
-    description "Path Computation End Points grouping.";
-  }
-
   grouping requested-metrics-info {
     description "requested metric";
     list requested-metrics {
@@ -284,6 +264,67 @@ module ietf-te-path-computation {
   }
 
   /*
+	 * These groupings should be removed when defined in te-types
+	 */
+	
+  grouping encoding-and-switching-type {
+		description
+		  "Common grouping to define the LSP encoding and switching types"
+
+    leaf encoding {
+      type identityref {
+        base te-types:lsp-encoding-types;
+      }
+      description "LSP encoding type";
+      reference "RFC3945";
+    }
+    leaf switching-type {
+      type identityref {
+        base te-types:switching-capabilities;
+      }
+      description "LSP switching type";
+      reference "RFC3945";
+    }
+  }
+
+	grouping preference {
+		description
+		  "Common grouping to define the tunnel/path preference"
+
+		leaf preference {
+      type uint8 {
+        range "1..255";
+      }
+      description
+        "Specifies a preference for this tunnel.
+        A lower number signifies a better preference";
+    }
+	}
+	
+  grouping end-points {
+		description
+		  "Common grouping to define the TE tunnel end-points"
+
+		leaf source {
+      type inet:ip-address;
+      description "TE tunnel source address.";
+    }
+    leaf destination {
+      type inet:ip-address;
+      description "P2P tunnel destination address";
+    }
+    leaf src-tp-id {
+      type binary;
+      description "TE tunnel source termination point identifier.";
+    }
+    leaf dst-tp-id {
+      type binary;
+      description "TE tunnel destination termination point identifier.";
+    }
+    description "Path Computation End Points grouping.";
+  }
+
+  /*
    * Root container
    */  
   container paths {
@@ -312,6 +353,8 @@ module ietf-te-path-computation {
           It must be present also in rpcs.";
       }
       uses end-points;
+			uses encoding-and-switching-type;
+      uses preference;
       uses te:bidir-assoc-properties;
       uses te-types:path-route-objects;
       uses te-types:generic-path-constraints;
@@ -348,4 +391,3 @@ module ietf-te-path-computation {
     }
   }
 }
-


### PR DESCRIPTION
Pull request to propose a fix to open issue #31

Three groupings have been created, while waiting them to be re-defined in te-types
